### PR TITLE
Fix canvas export

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,19 +117,11 @@
       }
       canvas.discardActiveObject();
       canvas.renderAll();
-      const exportCanvas = document.createElement('canvas');
-      exportCanvas.width = canvas.width;
-      exportCanvas.height = canvas.height;
-      const ctx = exportCanvas.getContext('2d');
-      ctx.fillStyle = "#000";
-      ctx.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
-      ctx.drawImage(canvas.lowerCanvasEl, 0, 0);
-      exportCanvas.toBlob((blob) => {
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = 'cumified.png';
-        link.click();
-      }, 'image/png');
+      const dataURL = canvas.toDataURL({ format: 'png' });
+      const link = document.createElement('a');
+      link.href = dataURL;
+      link.download = 'cumified.png';
+      link.click();
     }
 
     function resetCanvas() {


### PR DESCRIPTION
## Summary
- fix the `downloadImage` function to capture the full canvas using `canvas.toDataURL`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fd5c59170832b860db5d5416b01f3